### PR TITLE
Add support for months

### DIFF
--- a/days_ago.go
+++ b/days_ago.go
@@ -88,6 +88,42 @@ func GetDateStringRangeFromWordString(refTime time.Time, input string) (start, e
 	case "this year":
 		start = now.New(refTime).BeginningOfYear().Format(layout)
 		end = now.New(refTime).EndOfYear().Format(layout)
+	case "january", "jan":
+		start = now.New(refTime).BeginningOfYear().Format(layout)
+		end = now.New(refTime).BeginningOfYear().AddDate(0, 1, -1).Format(layout)
+	case "february", "feb":
+		start = now.New(refTime).BeginningOfYear().AddDate(0, 1, 0).Format(layout)
+		end = now.New(refTime).BeginningOfYear().AddDate(0, 2, -1).Format(layout)
+	case "march", "mar":
+		start = now.New(refTime).BeginningOfYear().AddDate(0, 2, 0).Format(layout)
+		end = now.New(refTime).BeginningOfYear().AddDate(0, 3, -1).Format(layout)
+	case "april", "apr":
+		start = now.New(refTime).BeginningOfYear().AddDate(0, 3, 0).Format(layout)
+		end = now.New(refTime).BeginningOfYear().AddDate(0, 4, -1).Format(layout)
+	case "may":
+		start = now.New(refTime).BeginningOfYear().AddDate(0, 4, 0).Format(layout)
+		end = now.New(refTime).BeginningOfYear().AddDate(0, 5, -1).Format(layout)
+	case "june", "jun":
+		start = now.New(refTime).BeginningOfYear().AddDate(0, 5, 0).Format(layout)
+		end = now.New(refTime).BeginningOfYear().AddDate(0, 6, -1).Format(layout)
+	case "july", "jul":
+		start = now.New(refTime).BeginningOfYear().AddDate(0, 6, 0).Format(layout)
+		end = now.New(refTime).BeginningOfYear().AddDate(0, 7, -1).Format(layout)
+	case "august", "aug":
+		start = now.New(refTime).BeginningOfYear().AddDate(0, 7, 0).Format(layout)
+		end = now.New(refTime).BeginningOfYear().AddDate(0, 8, -1).Format(layout)
+	case "september", "sep":
+		start = now.New(refTime).BeginningOfYear().AddDate(0, 8, 0).Format(layout)
+		end = now.New(refTime).BeginningOfYear().AddDate(0, 9, -1).Format(layout)
+	case "october", "oct":
+		start = now.New(refTime).BeginningOfYear().AddDate(0, 9, 0).Format(layout)
+		end = now.New(refTime).BeginningOfYear().AddDate(0, 10, -1).Format(layout)
+	case "november", "nov":
+		start = now.New(refTime).BeginningOfYear().AddDate(0, 10, 0).Format(layout)
+		end = now.New(refTime).BeginningOfYear().AddDate(0, 11, -1).Format(layout)
+	case "december", "dec":
+		start = now.New(refTime).BeginningOfYear().AddDate(0, 11, 0).Format(layout)
+		end = now.New(refTime).BeginningOfYear().AddDate(0, 12, -1).Format(layout)
 	default:
 		re := regexp.MustCompile("[0-9]+")
 		numArr := re.FindStringSubmatch(input)

--- a/days_ago_test.go
+++ b/days_ago_test.go
@@ -71,6 +71,41 @@ func TestGetDateStringRangeFromWordString(t *testing.T) {
 		{inputTime: time.Date(2017, time.September, 12, 23, 0, 0, 0, time.UTC), inputString: "this week", expectedStart: "2017-09-10", expectedEnd: "2017-09-16"},
 		{inputTime: time.Date(2017, time.September, 12, 23, 0, 0, 0, time.UTC), inputString: "this month", expectedStart: "2017-09-01", expectedEnd: "2017-09-30"},
 		{inputTime: time.Date(2017, time.September, 12, 23, 0, 0, 0, time.UTC), inputString: "this year", expectedStart: "2017-01-01", expectedEnd: "2017-12-31"},
+
+		{inputTime: time.Date(2017, time.September, 12, 23, 0, 0, 0, time.UTC), inputString: "october", expectedStart: "2017-10-01", expectedEnd: "2017-10-31"},
+		{inputTime: time.Date(2017, time.September, 12, 23, 0, 0, 0, time.UTC), inputString: "january", expectedStart: "2017-01-01", expectedEnd: "2017-01-31"},
+		{inputTime: time.Date(2017, time.September, 12, 23, 0, 0, 0, time.UTC), inputString: "jan", expectedStart: "2017-01-01", expectedEnd: "2017-01-31"},
+
+		{inputTime: time.Date(2017, time.September, 12, 23, 0, 0, 0, time.UTC), inputString: "february", expectedStart: "2017-02-01", expectedEnd: "2017-02-28"},
+		{inputTime: time.Date(2017, time.September, 12, 23, 0, 0, 0, time.UTC), inputString: "feb", expectedStart: "2017-02-01", expectedEnd: "2017-02-28"},
+
+		{inputTime: time.Date(2017, time.September, 12, 23, 0, 0, 0, time.UTC), inputString: "march", expectedStart: "2017-03-01", expectedEnd: "2017-03-31"},
+
+		{inputTime: time.Date(2017, time.September, 12, 23, 0, 0, 0, time.UTC), inputString: "april", expectedStart: "2017-04-01", expectedEnd: "2017-04-30"},
+		{inputTime: time.Date(2017, time.September, 12, 23, 0, 0, 0, time.UTC), inputString: "apr", expectedStart: "2017-04-01", expectedEnd: "2017-04-30"},
+
+		{inputTime: time.Date(2017, time.September, 12, 23, 0, 0, 0, time.UTC), inputString: "may", expectedStart: "2017-05-01", expectedEnd: "2017-05-31"},
+
+		{inputTime: time.Date(2017, time.September, 12, 23, 0, 0, 0, time.UTC), inputString: "june", expectedStart: "2017-06-01", expectedEnd: "2017-06-30"},
+		{inputTime: time.Date(2017, time.September, 12, 23, 0, 0, 0, time.UTC), inputString: "jun", expectedStart: "2017-06-01", expectedEnd: "2017-06-30"},
+
+		{inputTime: time.Date(2017, time.September, 12, 23, 0, 0, 0, time.UTC), inputString: "july", expectedStart: "2017-07-01", expectedEnd: "2017-07-31"},
+		{inputTime: time.Date(2017, time.September, 12, 23, 0, 0, 0, time.UTC), inputString: "jul", expectedStart: "2017-07-01", expectedEnd: "2017-07-31"},
+
+		{inputTime: time.Date(2017, time.September, 12, 23, 0, 0, 0, time.UTC), inputString: "august", expectedStart: "2017-08-01", expectedEnd: "2017-08-31"},
+		{inputTime: time.Date(2017, time.September, 12, 23, 0, 0, 0, time.UTC), inputString: "aug", expectedStart: "2017-08-01", expectedEnd: "2017-08-31"},
+
+		{inputTime: time.Date(2017, time.September, 12, 23, 0, 0, 0, time.UTC), inputString: "september", expectedStart: "2017-09-01", expectedEnd: "2017-09-30"},
+		{inputTime: time.Date(2017, time.September, 12, 23, 0, 0, 0, time.UTC), inputString: "sep", expectedStart: "2017-09-01", expectedEnd: "2017-09-30"},
+
+		{inputTime: time.Date(2017, time.September, 12, 23, 0, 0, 0, time.UTC), inputString: "october", expectedStart: "2017-10-01", expectedEnd: "2017-10-31"},
+		{inputTime: time.Date(2017, time.September, 12, 23, 0, 0, 0, time.UTC), inputString: "oct", expectedStart: "2017-10-01", expectedEnd: "2017-10-31"},
+
+		{inputTime: time.Date(2017, time.September, 12, 23, 0, 0, 0, time.UTC), inputString: "november", expectedStart: "2017-11-01", expectedEnd: "2017-11-30"},
+		{inputTime: time.Date(2017, time.September, 12, 23, 0, 0, 0, time.UTC), inputString: "nov", expectedStart: "2017-11-01", expectedEnd: "2017-11-30"},
+
+		{inputTime: time.Date(2017, time.September, 12, 23, 0, 0, 0, time.UTC), inputString: "december", expectedStart: "2017-12-01", expectedEnd: "2017-12-31"},
+		{inputTime: time.Date(2017, time.September, 12, 23, 0, 0, 0, time.UTC), inputString: "dec", expectedStart: "2017-12-01", expectedEnd: "2017-12-31"},
 	}
 
 	for _, eachTest := range tests {


### PR DESCRIPTION
Specific month names can be handled. Given the name of a month in either the full form or short, return the date range for the beginning and end.